### PR TITLE
Use AudioWorkletNode for realtime audio capture

### DIFF
--- a/examples/realtime/app/static/audio-processor.js
+++ b/examples/realtime/app/static/audio-processor.js
@@ -1,0 +1,11 @@
+class AudioProcessor extends AudioWorkletProcessor {
+    process(inputs) {
+        const inputChannel = inputs[0];
+        if (inputChannel && inputChannel[0]) {
+            this.port.postMessage(inputChannel[0]);
+        }
+        return true;
+    }
+}
+
+registerProcessor('audio-processor', AudioProcessor);

--- a/examples/realtime/cli/demo.py
+++ b/examples/realtime/cli/demo.py
@@ -52,7 +52,7 @@ class NoUIDemo:
         # Audio output state for callback system
         self.output_queue: queue.Queue[Any] = queue.Queue(maxsize=10)  # Buffer more chunks
         self.interrupt_event = threading.Event()
-        self.current_audio_chunk: np.ndarray | None = None  # type: ignore
+        self.current_audio_chunk: np.ndarray | None = None
         self.chunk_position = 0
 
     def _output_callback(self, outdata, frames: int, time, status) -> None:


### PR DESCRIPTION
## Summary
- capture microphone audio using `AudioWorkletNode` in realtime demo
- add audio worklet processor module
- remove unused type ignore in realtime CLI demo

## Testing
- `make format`
- `make lint`
- `make mypy`
- `OPENAI_API_KEY=dummy make tests`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9e57e3c83239a9e1ae7b93a32f8