### PR TITLE
Improve realtime audio playback queue and cleanup

### DIFF
--- a/examples/realtime/app/static/app.js
+++ b/examples/realtime/app/static/app.js
@@ -13,7 +13,8 @@ class RealtimeDemo {
         this.audioQueue = [];
         this.isPlayingAudio = false;
         this.playbackAudioContext = null;
-        this.currentAudioSource = null;
+        this.currentAudioSources = [];
+        this.nextAudioTime = 0;
         
         this.initializeElements();
         this.setupEventListeners();
@@ -64,6 +65,7 @@ class RealtimeDemo {
             this.ws.onclose = () => {
                 this.isConnected = false;
                 this.updateConnectionUI();
+                this.stopAudioPlayback();
             };
             
             this.ws.onerror = (error) => {
@@ -80,6 +82,7 @@ class RealtimeDemo {
             this.ws.close();
         }
         this.stopContinuousCapture();
+        this.stopAudioPlayback();
     }
     
     updateConnectionUI() {
@@ -352,107 +355,117 @@ class RealtimeDemo {
                 console.warn('Received empty audio data, skipping playback');
                 return;
             }
-            
+
             // Add to queue
             this.audioQueue.push(audioBase64);
-            
+
             // Start processing queue if not already playing
             if (!this.isPlayingAudio) {
                 this.processAudioQueue();
             }
-            
+
         } catch (error) {
             console.error('Failed to play audio:', error);
         }
     }
-    
-    async processAudioQueue() {
+
+    processAudioQueue() {
         if (this.isPlayingAudio || this.audioQueue.length === 0) {
             return;
         }
-        
+
         this.isPlayingAudio = true;
-        
+
         // Initialize audio context if needed
         if (!this.playbackAudioContext) {
             this.playbackAudioContext = new AudioContext({ sampleRate: 24000 });
+            this.nextAudioTime = this.playbackAudioContext.currentTime;
         }
-        
+
         while (this.audioQueue.length > 0) {
             const audioBase64 = this.audioQueue.shift();
-            await this.playAudioChunk(audioBase64);
+            this.scheduleAudioChunk(audioBase64);
         }
-        
+
         this.isPlayingAudio = false;
     }
-    
-    async playAudioChunk(audioBase64) {
-        return new Promise((resolve, reject) => {
-            try {
-                // Decode base64 to ArrayBuffer
-                const binaryString = atob(audioBase64);
-                const bytes = new Uint8Array(binaryString.length);
-                for (let i = 0; i < binaryString.length; i++) {
-                    bytes[i] = binaryString.charCodeAt(i);
-                }
-                
-                const int16Array = new Int16Array(bytes.buffer);
-                
-                if (int16Array.length === 0) {
-                    console.warn('Audio chunk has no samples, skipping');
-                    resolve();
-                    return;
-                }
-                
-                const float32Array = new Float32Array(int16Array.length);
-                
-                // Convert int16 to float32
-                for (let i = 0; i < int16Array.length; i++) {
-                    float32Array[i] = int16Array[i] / 32768.0;
-                }
-                
-                const audioBuffer = this.playbackAudioContext.createBuffer(1, float32Array.length, 24000);
-                audioBuffer.getChannelData(0).set(float32Array);
-                
-                const source = this.playbackAudioContext.createBufferSource();
-                source.buffer = audioBuffer;
-                source.connect(this.playbackAudioContext.destination);
-                
-                // Store reference to current source
-                this.currentAudioSource = source;
-                
-                source.onended = () => {
-                    this.currentAudioSource = null;
-                    resolve();
-                };
-                source.start();
-                
-            } catch (error) {
-                console.error('Failed to play audio chunk:', error);
-                reject(error);
+
+    scheduleAudioChunk(audioBase64) {
+        try {
+            // Decode base64 to ArrayBuffer
+            const binaryString = atob(audioBase64);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
             }
-        });
+
+            const int16Array = new Int16Array(bytes.buffer);
+
+            if (int16Array.length === 0) {
+                console.warn('Audio chunk has no samples, skipping');
+                return;
+            }
+
+            const float32Array = new Float32Array(int16Array.length);
+
+            // Convert int16 to float32
+            for (let i = 0; i < int16Array.length; i++) {
+                float32Array[i] = int16Array[i] / 32768.0;
+            }
+
+            const audioBuffer = this.playbackAudioContext.createBuffer(1, float32Array.length, 24000);
+            audioBuffer.getChannelData(0).set(float32Array);
+
+            const source = this.playbackAudioContext.createBufferSource();
+            source.buffer = audioBuffer;
+            source.connect(this.playbackAudioContext.destination);
+
+            const startTime = Math.max(this.nextAudioTime, this.playbackAudioContext.currentTime);
+            source.start(startTime);
+            this.nextAudioTime = startTime + audioBuffer.duration;
+
+            this.currentAudioSources.push(source);
+            source.onended = () => {
+                const index = this.currentAudioSources.indexOf(source);
+                if (index !== -1) {
+                    this.currentAudioSources.splice(index, 1);
+                }
+            };
+
+        } catch (error) {
+            console.error('Failed to play audio chunk:', error);
+        }
     }
-    
+
     stopAudioPlayback() {
         console.log('Stopping audio playback due to interruption');
-        
-        // Stop current audio source if playing
-        if (this.currentAudioSource) {
+
+        // Stop any scheduled sources
+        this.currentAudioSources.forEach(source => {
             try {
-                this.currentAudioSource.stop();
-                this.currentAudioSource = null;
+                source.stop();
             } catch (error) {
                 console.error('Error stopping audio source:', error);
             }
-        }
-        
+        });
+        this.currentAudioSources = [];
+
         // Clear the audio queue
         this.audioQueue = [];
-        
+
         // Reset playback state
         this.isPlayingAudio = false;
-        
+        this.nextAudioTime = 0;
+
+        if (this.playbackAudioContext) {
+            try {
+                this.playbackAudioContext.close();
+            } catch (error) {
+                console.error('Error closing audio context:', error);
+            }
+            this.playbackAudioContext = null;
+        }
+
         console.log('Audio playback stopped and queue cleared');
     }
     


### PR DESCRIPTION
## Summary
- schedule audio chunks with tracked playback time to avoid stutter
- reset playback timing and sources on interruptions and disconnects
- close audio context and clear queue when playback stops

## Testing
- `make format` *(fails: examples/realtime/app/agent.py:388:107: W291 Trailing whitespace)*
- `make lint` *(fails: examples/realtime/app/agent.py:388:107: W291 Trailing whitespace)*
- `make mypy` *(fails: src/agents/extensions/models/litellm_model.py:14: error: Cannot find implementation or library stub for module named "litellm" [import-not-found])* 
- `make tests` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c15ea1ab648323ab2b36ab6866d2d1