### PR TITLE
Add session management to Unity realtime example

### DIFF
--- a/examples/realtime/app/agent.py
+++ b/examples/realtime/app/agent.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Any, Iterable, Tuple
 import unicodedata
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import Any
 
 from agents import function_tool
 from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
-from agents.realtime import RealtimeAgent, realtime_handoff
+from agents.realtime import RealtimeAgent
 
 """
 When running the UI example locally, you can edit this file to change the setup.
@@ -254,11 +255,10 @@ SPANISH_DAYS = {
     "domingo": "sunday",
 }
 
+
 def _strip_accents(s: str) -> str:
-    return "".join(
-        c for c in unicodedata.normalize("NFD", s)
-        if unicodedata.category(c) != "Mn"
-    )
+    return "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
+
 
 def _normalize_day(day: str) -> str:
     """
@@ -274,20 +274,25 @@ def _normalize_day(day: str) -> str:
         return SPANISH_DAYS[day_clean]
     return day_clean  # asume inglés válido (monday..sunday)
 
+
 # ---------------------------------------------------------------------
 # Helpers para recorrer la estructura anidada
 # ---------------------------------------------------------------------
-def _iter_day_dishes(day_block: dict[str, list[dict[str, Any]]]) -> Iterable[Tuple[str, dict[str, Any]]]:
+def _iter_day_dishes(
+    day_block: dict[str, list[dict[str, Any]]],
+) -> Iterable[tuple[str, dict[str, Any]]]:
     """Itera por todos los platos (primeros, segundos y postres) de un día."""
     for course_key in ("first_course", "second_course", "dessert"):
         for dish in day_block.get(course_key, []):
             yield course_key, dish
+
 
 def _iter_all_dishes() -> Iterable[dict[str, Any]]:
     """Itera por todos los platos de toda la semana."""
     for day_block in MENUS.values():
         for _, dish in _iter_day_dishes(day_block):
             yield dish
+
 
 # ---------------------------------------------------------------------
 # Tools
@@ -307,7 +312,7 @@ def menu_lookup(day: str) -> str:
 
     primeros = ", ".join(d["name"] for d in day_block.get("first_course", [])) or "—"
     segundos = ", ".join(d["name"] for d in day_block.get("second_course", [])) or "—"
-    postres  = ", ".join(d["name"] for d in day_block.get("dessert", [])) or "—"
+    postres = ", ".join(d["name"] for d in day_block.get("dessert", [])) or "—"
 
     # Respuesta legible en varias líneas
     return (
@@ -316,6 +321,7 @@ def menu_lookup(day: str) -> str:
         f"- Segundos: {segundos}\n"
         f"- Postres: {postres}"
     )
+
 
 @function_tool
 def nutrition_info(dish: str) -> str:
@@ -336,6 +342,7 @@ def nutrition_info(dish: str) -> str:
             )
     return f"La información nutricional de {dish} no está disponible."
 
+
 @function_tool
 def allergen_check(dish: str) -> str:
     """
@@ -354,6 +361,7 @@ def allergen_check(dish: str) -> str:
             return f"{d['name']} contiene: {', '.join(allergens)}."
     return f"La información de alérgenos de {dish} no está disponible."
 
+
 @function_tool
 async def place_order(dish: str, quantity: int) -> str:
     """
@@ -362,6 +370,7 @@ async def place_order(dish: str, quantity: int) -> str:
     """
     # Aquí ya está “mockeado”: no se hace ninguna petición de red.
     return f"Pedido realizado: {quantity} x {dish}."
+
 
 # ---------------------------------------------------------------------
 # Agents
@@ -376,7 +385,7 @@ Use the following routine to support the customer.
     1. Use the menu lookup tool to reply to the customer giving first plates, second and dessert options of selected day.
     2. Ask the customer if it wants to repeat the list.
     3. Ask the customer if it wants to know allergic or nutrition info.
-    If the customer asks a question that is not related to the routine, transfer back to the triage agent. 
+    If the customer asks a question that is not related to the routine, transfer back to the triage agent.
 
 Use the menu lookup tool to tell customers what is available for the requested day.""",
     tools=[menu_lookup],

--- a/examples/realtime/app/server.py
+++ b/examples/realtime/app/server.py
@@ -11,8 +11,12 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from typing_extensions import assert_never
 
-from agents.realtime import RealtimeRunner, RealtimeSession, RealtimeSessionEvent, \
-    RealtimeRunConfig, RealtimeSessionModelSettings, RealtimeModelConfig, RealtimeModel, OpenAIRealtimeWebSocketModel
+from agents.realtime import (
+    RealtimeRunner,
+    RealtimeSession,
+    RealtimeSessionEvent,
+    RealtimeSessionModelSettings,
+)
 
 # Import TwilioHandler class - handle both module and package use cases
 if TYPE_CHECKING:
@@ -42,7 +46,7 @@ class RealtimeWebSocketManager:
         await websocket.accept()
         self.websockets[session_id] = websocket
 
-        model_settings: RealtimeSessionModelSettings = {
+        _model_settings: RealtimeSessionModelSettings = {
             "model_name": "gpt-realtime",
             "modalities": ["text", "audio"],
             "voice": "marin",
@@ -60,7 +64,7 @@ class RealtimeWebSocketManager:
             # "handoffs": [],                        # opcional
             # "tracing": {"enabled": False},         # opcional
         }
-        #config = RealtimeRunConfig(model_settings=model_settings)
+        # config = RealtimeRunConfig(model_settings=model_settings)
         runner = RealtimeRunner(starting_agent=get_starting_agent())
         # runner = RealtimeRunner(starting_agent=get_starting_agent(),
         #                         config=RealtimeRunConfig(model_settings=model_settings))

--- a/examples/realtime/unity/agent.py
+++ b/examples/realtime/unity/agent.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Any, Iterable, Tuple
 import unicodedata
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import Any
 
 from agents import function_tool
 from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
-from agents.realtime import RealtimeAgent, realtime_handoff
+from agents.realtime import RealtimeAgent
 
 """
 When running the UI example locally, you can edit this file to change the setup.
@@ -254,11 +255,10 @@ SPANISH_DAYS = {
     "domingo": "sunday",
 }
 
+
 def _strip_accents(s: str) -> str:
-    return "".join(
-        c for c in unicodedata.normalize("NFD", s)
-        if unicodedata.category(c) != "Mn"
-    )
+    return "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
+
 
 def _normalize_day(day: str) -> str:
     """
@@ -274,20 +274,25 @@ def _normalize_day(day: str) -> str:
         return SPANISH_DAYS[day_clean]
     return day_clean  # asume inglés válido (monday..sunday)
 
+
 # ---------------------------------------------------------------------
 # Helpers para recorrer la estructura anidada
 # ---------------------------------------------------------------------
-def _iter_day_dishes(day_block: dict[str, list[dict[str, Any]]]) -> Iterable[Tuple[str, dict[str, Any]]]:
+def _iter_day_dishes(
+    day_block: dict[str, list[dict[str, Any]]],
+) -> Iterable[tuple[str, dict[str, Any]]]:
     """Itera por todos los platos (primeros, segundos y postres) de un día."""
     for course_key in ("first_course", "second_course", "dessert"):
         for dish in day_block.get(course_key, []):
             yield course_key, dish
+
 
 def _iter_all_dishes() -> Iterable[dict[str, Any]]:
     """Itera por todos los platos de toda la semana."""
     for day_block in MENUS.values():
         for _, dish in _iter_day_dishes(day_block):
             yield dish
+
 
 # ---------------------------------------------------------------------
 # Tools
@@ -307,7 +312,7 @@ def menu_lookup(day: str) -> str:
 
     primeros = ", ".join(d["name"] for d in day_block.get("first_course", [])) or "—"
     segundos = ", ".join(d["name"] for d in day_block.get("second_course", [])) or "—"
-    postres  = ", ".join(d["name"] for d in day_block.get("dessert", [])) or "—"
+    postres = ", ".join(d["name"] for d in day_block.get("dessert", [])) or "—"
 
     # Respuesta legible en varias líneas
     return (
@@ -316,6 +321,7 @@ def menu_lookup(day: str) -> str:
         f"- Segundos: {segundos}\n"
         f"- Postres: {postres}"
     )
+
 
 @function_tool
 def nutrition_info(dish: str) -> str:
@@ -336,6 +342,7 @@ def nutrition_info(dish: str) -> str:
             )
     return f"La información nutricional de {dish} no está disponible."
 
+
 @function_tool
 def allergen_check(dish: str) -> str:
     """
@@ -354,6 +361,7 @@ def allergen_check(dish: str) -> str:
             return f"{d['name']} contiene: {', '.join(allergens)}."
     return f"La información de alérgenos de {dish} no está disponible."
 
+
 @function_tool
 async def place_order(dish: str, quantity: int) -> str:
     """
@@ -362,6 +370,7 @@ async def place_order(dish: str, quantity: int) -> str:
     """
     # Aquí ya está “mockeado”: no se hace ninguna petición de red.
     return f"Pedido realizado: {quantity} x {dish}."
+
 
 # ---------------------------------------------------------------------
 # Agents
@@ -376,7 +385,7 @@ Use the following routine to support the customer.
     1. Use the menu lookup tool to reply to the customer giving first plates, second and dessert options of selected day.
     2. Ask the customer if it wants to repeat the list.
     3. Ask the customer if it wants to know allergic or nutrition info.
-    If the customer asks a question that is not related to the routine, transfer back to the triage agent. 
+    If the customer asks a question that is not related to the routine, transfer back to the triage agent.
 
 Use the menu lookup tool to tell customers what is available for the requested day.""",
     tools=[menu_lookup],

--- a/examples/realtime/unity/static/index.html
+++ b/examples/realtime/unity/static/index.html
@@ -8,9 +8,8 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f8f9fa; height: 100vh; display: flex; flex-direction: column; }
         .header { background: white; padding: 1rem; border-bottom: 1px solid #e1e5e9; display: flex; justify-content: space-between; align-items: center; }
-        .connect-btn { padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-weight: 500; }
-        .connect-btn.disconnected { background: #0066cc; color: white; }
-        .connect-btn.connected { background: #dc3545; color: white; }
+        .refresh-btn { padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-weight: 500; background: #0066cc; color: white; margin-left: 0.5rem; }
+        #sessionSelect { padding: 0.5rem; border-radius: 6px; }
         .main { flex: 1; display: flex; gap: 1rem; padding: 1rem; height: calc(100vh - 80px); }
         .messages-pane { flex: 2; background: white; border-radius: 8px; display: flex; flex-direction: column; overflow: hidden; }
         .messages-header { padding: 1rem; border-bottom: 1px solid #e1e5e9; font-weight: 600; }
@@ -35,8 +34,10 @@
     <div class="header">
         <h1>Unity NPC Log</h1>
         <div>
-            <input id="sessionInput" placeholder="session id" />
-            <button id="connectBtn" class="connect-btn disconnected">Connect</button>
+            <select id="sessionSelect">
+                <option value="">Select session</option>
+            </select>
+            <button id="refreshBtn" class="refresh-btn">Refresh</button>
             <span id="status" class="status disconnected">Disconnected</span>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow multiple realtime sessions with automatic IDs
- expose session list API for viewer UI
- add dropdown UI to monitor active conversations
- fix lint warnings in example agents

## Testing
- `make format`
- `make lint`
- `make mypy`
- `OPENAI_API_KEY=dummy make tests`


------
https://chatgpt.com/codex/tasks/task_e_68c1c75f81548323bbf1f9875fed4251