### PR TITLE
Fix duplicate text and disabled button cursor in realtime demo

### DIFF
--- a/examples/realtime/app/static/app.js
+++ b/examples/realtime/app/static/app.js
@@ -390,9 +390,15 @@ class RealtimeDemo {
             if (Array.isArray(item.content)) {
                 for (const contentPart of item.content) {
                     if (!contentPart || typeof contentPart !== 'object') continue;
-                    if (contentPart.type === 'text' && contentPart.text) {
+                    if (contentPart.type === 'input_text' && contentPart.text) {
+                        // Server may echo the same text as both input_text and text.
+                        // Prefer input_text for user messages to avoid duplicates.
                         content += contentPart.text;
-                    } else if (contentPart.type === 'input_text' && contentPart.text) {
+                    } else if (
+                        contentPart.type === 'text' &&
+                        contentPart.text &&
+                        role !== 'user'
+                    ) {
                         content += contentPart.text;
                     } else if (contentPart.type === 'input_audio' && contentPart.transcript) {
                         content += contentPart.transcript;

--- a/examples/realtime/app/static/index.html
+++ b/examples/realtime/app/static/index.html
@@ -50,7 +50,11 @@
         .connect-btn:hover {
             opacity: 0.9;
         }
-        
+
+        button:disabled {
+            cursor: not-allowed;
+        }
+
         .main {
             flex: 1;
             display: flex;


### PR DESCRIPTION
## Summary
- avoid duplicate user text in realtime demo by ignoring echoed `text`
- show not-allowed cursor for disabled buttons

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68c6feb6bc2083238e1159e2501cd0d8