### PR TITLE
Add Unity client example

### DIFF
--- a/examples/realtime/unity/client/README.md
+++ b/examples/realtime/unity/client/README.md
@@ -1,0 +1,16 @@
+# Unity Realtime Client
+
+Este ejemplo muestra cómo conectarse al servidor de FastAPI ubicado en `server.py` desde un proyecto de Unity utilizando WebSockets.
+
+## Uso
+
+1. Asegúrate de que el servidor esté en ejecución:
+   ```bash
+   cd examples/realtime/unity
+   uv run python server.py
+   ```
+2. Copia `RealtimeUnityClient.cs` en tu proyecto de Unity y asígnalo a un `GameObject`.
+3. Ejecuta la escena. El cliente se conectará automáticamente y registrará los mensajes recibidos.
+4. Llama a `SendText("hola")` o `SendAudio(muestras)` para enviar datos al servidor.
+
+El script utiliza `System.Net.WebSockets` disponible en las versiones modernas de Unity.

--- a/examples/realtime/unity/client/RealtimeUnityClient.cs
+++ b/examples/realtime/unity/client/RealtimeUnityClient.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class RealtimeUnityClient : MonoBehaviour
+{
+    [Tooltip("Base WebSocket URL, e.g. ws://localhost:8000/ws")] public string serverUrl = "ws://localhost:8000/ws";
+    private ClientWebSocket socket;
+    private CancellationTokenSource cts;
+    private string sessionId;
+
+    public async void Start()
+    {
+        await Connect();
+    }
+
+    public async Task Connect()
+    {
+        sessionId = Guid.NewGuid().ToString();
+        socket = new ClientWebSocket();
+        cts = new CancellationTokenSource();
+        var uri = new Uri($"{serverUrl}/{sessionId}");
+        await socket.ConnectAsync(uri, cts.Token);
+        Debug.Log($"Connected to {uri}.");
+        _ = ReceiveLoop();
+    }
+
+    private async Task ReceiveLoop()
+    {
+        var buffer = new byte[8192];
+        while (socket.State == WebSocketState.Open)
+        {
+            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cts.Token);
+                break;
+            }
+            var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            Debug.Log($"Received: {message}");
+        }
+    }
+
+    public async void SendText(string text)
+    {
+        if (socket == null || socket.State != WebSocketState.Open)
+        {
+            Debug.LogWarning("WebSocket is not connected.");
+            return;
+        }
+
+        var payload = $"{{\"type\":\"text\",\"text\":\"{text}\"}}";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cts.Token);
+    }
+
+    public async void SendAudio(short[] samples)
+    {
+        if (socket == null || socket.State != WebSocketState.Open)
+        {
+            Debug.LogWarning("WebSocket is not connected.");
+            return;
+        }
+
+        string data = string.Join(",", samples);
+        var payload = $"{{\"type\":\"audio\",\"data\":[{data}]}}";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cts.Token);
+    }
+
+    private async void OnDestroy()
+    {
+        if (socket != null)
+        {
+            if (socket.State == WebSocketState.Open)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "closing", cts.Token);
+            }
+            socket.Dispose();
+            cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add sample Unity WebSocket client to talk to realtime server
- document usage for Unity client

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`
- `make build-docs`


------
https://chatgpt.com/codex/tasks/task_e_68c742d0ae4c83239f05302b07cf0145