### PR TITLE
Add Docker support for Unity realtime server

### DIFF
--- a/examples/realtime/unity/client/Dockerfile
+++ b/examples/realtime/unity/client/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+FROM python:3.13.7-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml ./
+COPY src ./src
+
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir \
+        ".[realtime]" \
+        "fastapi>=0.115,<1" \
+        "uvicorn>=0.30,<1"
+
+COPY examples/realtime/unity ./examples/realtime/unity
+
+WORKDIR /app/examples/realtime/unity
+
+EXPOSE 8000
+
+CMD ["python", "server.py"]

--- a/examples/realtime/unity/client/README.md
+++ b/examples/realtime/unity/client/README.md
@@ -14,3 +14,15 @@ Este ejemplo muestra cómo conectarse al servidor de FastAPI ubicado en `server.
 4. Llama a `SendText("hola")` o `SendAudio(muestras)` para enviar datos al servidor.
 
 El script utiliza `System.Net.WebSockets` disponible en las versiones modernas de Unity.
+
+## Ejecutar el servidor con Docker
+
+1. Construye la imagen desde la raíz del repositorio para que el contenedor tenga acceso al código del servidor y al SDK:
+   ```bash
+   docker build -f examples/realtime/unity/client/Dockerfile -t unity-realtime-server .
+   ```
+2. Inicia el contenedor exponiendo el puerto 8000 (ajusta la variable `OPENAI_API_KEY` con tu clave):
+   ```bash
+   docker run --rm -p 8000:8000 -e OPENAI_API_KEY=tu_clave unity-realtime-server
+   ```
+3. Accede a http://localhost:8000 para usar la interfaz web y prueba tu cliente de Unity apuntando al mismo endpoint.


### PR DESCRIPTION
## Summary
- add a Python 3.13.7 slim based Dockerfile for the realtime Unity server example
- copy the example code and SDK into the image and run server.py by default
- document Docker build and run instructions in the Unity client README

## Testing
- not run (documentation and container configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68c91b84d7fc8323a7b7f6730cf6850c